### PR TITLE
Improve Gallery performance on Windows

### DIFF
--- a/scripts/images_history.py
+++ b/scripts/images_history.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import time
-import hashlib
+import stat
 import gradio as gr
 import modules.extras
 import modules.ui
@@ -9,6 +9,7 @@ from modules.shared import opts, cmd_opts
 from modules import shared, scripts
 from modules import script_callbacks
 from pathlib import Path
+from typing import List, Tuple
 
 faverate_tab_name = "Favorites"
 tabs_list = ["txt2img", "img2img", "Extras", faverate_tab_name, "Others"]
@@ -78,34 +79,28 @@ def delete_image(delete_num, name, filenames, image_index, visible_num):
             i += 1
     return new_file_list, 1, visible_num
 
-def traverse_all_files(curr_path, image_list):
-    try:
-        f_list = os.listdir(curr_path)
-    except:
-        if os.path.splitext(curr_path)[1] in image_ext_list:
-            image_list.append(curr_path)
-        return image_list
-    for file in f_list:
-        file = os.path.join(curr_path, file)
-        if os.path.isfile(file) and os.path.splitext(file)[1] in image_ext_list:
-            image_list.append(file)
-        else:
-            image_list = traverse_all_files(file, image_list)
+def traverse_all_files(curr_path, image_list) -> List[Tuple[str, os.stat_result]]:
+    f_list = [(os.path.join(curr_path, entry.name), entry.stat()) for entry in os.scandir(curr_path)]
+    for f_info in f_list:
+        fname, fstat = f_info
+        if os.path.splitext(fname)[1] in image_ext_list:
+            image_list.append(f_info)
+        elif stat.S_ISDIR(fstat.st_mode):
+            image_list = traverse_all_files(fname, image_list)
     return image_list
 
-def get_all_images(dir_name, sort_by, keyword):    
-    filenames = []   
-    filenames = traverse_all_files(dir_name, filenames)  
+
+def get_all_images(dir_name, sort_by, keyword):
+    fileinfos = traverse_all_files(dir_name, [])
     keyword = keyword.strip(" ")
-    if len(keyword) != 0:        
-        filenames = [x for x in filenames if keyword in x]
-    total_num = len(filenames) 
+    if len(keyword) != 0:
+        fileinfos = [x for x in fileinfos if keyword in x[0]]
     if sort_by == "date":
-        filenames = [(os.path.getmtime(file), file) for file in filenames ]
-        sort_array = sorted(filenames, key=lambda x:-x[0])
-        filenames = [x[1] for x in sort_array]
+        fileinfos = sorted(fileinfos, key=lambda x: -x[1].st_mtime)
     elif sort_by == "path name":
-        sort_array = sorted(filenames)        
+        fileinfos = sorted(fileinfos)
+
+    filenames = [finfo[0] for finfo in fileinfos]
     return filenames
 
 def get_image_page(img_path, page_index, filenames, keyword, sort_by):


### PR DESCRIPTION
10x speed-up refreshing gallery using 'sort by date' on Windows (with images are over a network drive... unsure of speedup on local machine) by using os.scandir.

Neglible effect on Linux.