### PR TITLE
Q.o.L. Features and README.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-# stable-diffusion-webui-images_browse
+# stable-diffusion-webui-images_browser
+
 This an extension for [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui)
 
 This an images browser for browsing past generated pictures， view their generated infomations，send the prompt to txt2img or img2img， collect images to your "faveries" fold, delete the images you no longer need， and you can also browse images in any folds in your computer  
 ![image](https://s6.jpg.cm/2022/10/24/PJjuZt.png)
 
-go to the directory \<stable-diffusion-webui project path\>/extensions and run command  to install:
+go to the directory \<stable-diffusion-webui project path\>/extensions and run command to install:
 
 `git clone https://github.com/yfszzx/stable-diffusion-webui-images-browser `
 
 and restart your stable-diffusion-webui, then you can see the new tab "Images Browser"
 
- [See here for more install details]( https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Extensions)
-
-
+[See here for more install details](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Extensions)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# stable-diffusion-webui-images_browser
+# stable-diffusion-webui-images-browser
 
 This an extension for [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui)
 

--- a/scripts/images_history.py
+++ b/scripts/images_history.py
@@ -65,8 +65,9 @@ def delete_image(delete_num, name, filenames, image_index, visible_num):
                     if visible_num == image_index:
                         new_file_list.append(name)
                         i += 1
-                        continue                    
-                    print(f"Delete file {name}")
+                        continue
+                    if opts.images_delete_message:
+                        print(f"Deleting file {name}")
                     os.remove(name)
                     visible_num -= 1
                     txt_file = os.path.splitext(name)[0] + ".txt"
@@ -80,6 +81,8 @@ def delete_image(delete_num, name, filenames, image_index, visible_num):
     return new_file_list, 1, visible_num
 
 def traverse_all_files(curr_path, image_list) -> List[Tuple[str, os.stat_result]]:
+    if curr_path == "":
+        return image_list
     f_list = [(os.path.join(curr_path, entry.name), entry.stat()) for entry in os.scandir(curr_path)]
     for f_info in f_list:
         fname, fstat = f_info
@@ -155,9 +158,10 @@ def change_dir(img_dir, path_recorder, load_switch, img_path_history):
             path_recorder.append(img_dir)
         if os.path.exists(path_recorder_filename):
             os.remove(path_recorder_filename)
-        with open(path_recorder_filename, "a") as f:
-            for x in path_recorder:
-                f.write(x + "\n")
+        if opts.images_record_paths:
+            with open(path_recorder_filename, "a") as f:
+                for x in path_recorder:
+                    f.write(x + "\n")
         return "", gr.update(visible=True), gr.Dropdown.update(choices=path_recorder, value=img_dir), path_recorder, img_dir
     else:
         return warning, gr.update(visible=False), img_path_history, path_recorder, load_switch
@@ -310,6 +314,8 @@ def on_ui_tabs():
 def on_ui_settings():
     section = ('images-history', "Images Browser")
     shared.opts.add_option("images_history_preload", shared.OptionInfo(False, "Preload images at startup", section=section))
+    shared.opts.add_option("images_record_paths", shared.OptionInfo(True, "Record accessable images directories", section=section))
+    shared.opts.add_option("images_delete_message", shared.OptionInfo(True, "Print image deletion messages to the console", section=section))
     shared.opts.add_option("images_history_page_columns", shared.OptionInfo(6, "Number of columns on the page", section=section))
     shared.opts.add_option("images_history_page_rows", shared.OptionInfo(6, "Number of rows on the page", section=section))
     shared.opts.add_option("images_history_pages_perload", shared.OptionInfo(20, "Minimum number of pages per load", section=section))


### PR DESCRIPTION
Added 2 new settings:
 - Option to only store the directories accessed via the "Others" tab for the session. (Clears on refresh/restart)
 - Option to stop the printing of the deleted file's name to the console.

README.md changes:
 - Updated the title to match the new repo name
 - Removed an extra space
 - Ran "Prettier" formatting